### PR TITLE
Release trust hardening for v0.1.4 readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - release packaging が source snapshot、row counts、git commit、tool version を記録するようになった
 - release publish script が bundle 一式を GitHub Release asset として upload するようになった
 - OpenAPI の dataset history / change detail description と `API_SPEC.md` の読み方を同期した
+- README / release docs / generated SQLite artifact notes に consumer-side verification flow を追加した
 
 ## v0.1.0
 

--- a/README.md
+++ b/README.md
@@ -232,10 +232,37 @@ SQLite artifact を配布物として固める:
 GitHub Release までまとめて公開する:
 
 ```bash
-./scripts/publish_sqlite_release.sh postgres v0.1.1
+./scripts/publish_sqlite_release.sh postgres v0.1.4
 ```
 
-配布物は `artifacts/sqlite/` に出力されます。
+配布物は `artifacts/sqlite/` に出力されます。公開済み tag は載せ替えず、
+次の patch tag で進めます。上の例は、最新 tag が `v0.1.3` の状態から
+`v0.1.4` を切る想定です。
+
+公開済み release を利用者側で検証する最短経路:
+
+```bash
+REPO=mt4110/station_converter_ja
+TAG=v0.1.4
+mkdir -p "tmp/release-${TAG}"
+gh release download "$TAG" -R "$REPO" -D "tmp/release-${TAG}" --clobber \
+  -p stations.sqlite3 \
+  -p manifest.json \
+  -p SOURCE_METADATA.json \
+  -p checksums.txt \
+  -p CHANGELOG.md \
+  -p RELEASE_NOTES.md \
+  -p README_SQLITE.md \
+  -p SBOM.spdx.json
+cd "tmp/release-${TAG}"
+shasum -a 256 -c checksums.txt
+gh attestation verify stations.sqlite3 -R "$REPO"
+gh attestation verify stations.sqlite3 -R "$REPO" \
+  --predicate-type https://spdx.dev/Document/v2.3
+```
+
+この artifact の freshness は latest available MLIT N02 snapshot までであり、
+real-time railway data ではありません。
 
 ## Docs
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -136,10 +136,37 @@ Build a distributable SQLite bundle:
 Publish the SQLite bundle to a GitHub Release:
 
 ```bash
-./scripts/publish_sqlite_release.sh postgres v0.1.1
+./scripts/publish_sqlite_release.sh postgres v0.1.4
 ```
 
-Outputs are written to `artifacts/sqlite/`.
+Outputs are written to `artifacts/sqlite/`. Do not move an already published tag;
+publish the hardened assets with a new patch tag. This example assumes `v0.1.3`
+is currently the latest tag and the next patch tag is `v0.1.4`.
+
+Fast consumer-side verification for a published release:
+
+```bash
+REPO=mt4110/station_converter_ja
+TAG=v0.1.4
+mkdir -p "tmp/release-${TAG}"
+gh release download "$TAG" -R "$REPO" -D "tmp/release-${TAG}" --clobber \
+  -p stations.sqlite3 \
+  -p manifest.json \
+  -p SOURCE_METADATA.json \
+  -p checksums.txt \
+  -p CHANGELOG.md \
+  -p RELEASE_NOTES.md \
+  -p README_SQLITE.md \
+  -p SBOM.spdx.json
+cd "tmp/release-${TAG}"
+shasum -a 256 -c checksums.txt
+gh attestation verify stations.sqlite3 -R "$REPO"
+gh attestation verify stations.sqlite3 -R "$REPO" \
+  --predicate-type https://spdx.dev/Document/v2.3
+```
+
+The artifact freshness claim is limited to the latest available MLIT N02 snapshot;
+it is not real-time railway data.
 
 ## Docs
 

--- a/docs/ARTIFACTS.md
+++ b/docs/ARTIFACTS.md
@@ -38,7 +38,31 @@ artifacts/sqlite/station_converter_ja-<release-version>-sqlite-<timestamp>/
 
 ## Verification
 
+GitHub Release から asset を取得します。
+
+```bash
+REPO=mt4110/station_converter_ja
+TAG=v0.1.4
+mkdir -p "tmp/release-${TAG}"
+gh release download "$TAG" -R "$REPO" -D "tmp/release-${TAG}" --clobber \
+  -p stations.sqlite3 \
+  -p manifest.json \
+  -p SOURCE_METADATA.json \
+  -p checksums.txt \
+  -p CHANGELOG.md \
+  -p RELEASE_NOTES.md \
+  -p README_SQLITE.md \
+  -p SBOM.spdx.json
+cd "tmp/release-${TAG}"
+```
+
 SHA-256:
+
+```bash
+shasum -a 256 -c checksums.txt
+```
+
+Linux で `sha256sum` がある場合:
 
 ```bash
 sha256sum -c checksums.txt
@@ -47,16 +71,21 @@ sha256sum -c checksums.txt
 artifact attestation:
 
 ```bash
-gh attestation verify stations.sqlite3 -R mt4110/station_converter_ja
+gh attestation verify stations.sqlite3 -R "$REPO"
 ```
 
 SBOM attestation:
 
 ```bash
 gh attestation verify stations.sqlite3 \
-  -R mt4110/station_converter_ja \
+  -R "$REPO" \
   --predicate-type https://spdx.dev/Document/v2.3
 ```
+
+`manifest.json` は source snapshot、row counts、git commit、tool version を持ちます。
+`SOURCE_METADATA.json` は export に入った source snapshot history を持ちます。
+この bundle は latest available MLIT N02 snapshot を配るためのもので、
+real-time railway data ではありません。
 
 ## Release workflow
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -154,6 +154,12 @@ GitHub Release まで載せる場合:
 ./scripts/publish_sqlite_release.sh postgres v0.1.4
 ```
 
+MySQL を primary write にしている場合:
+
+```bash
+./scripts/publish_sqlite_release.sh mysql v0.1.4
+```
+
 生成される bundle の中身と検証方法は [`docs/ARTIFACTS.md`](./ARTIFACTS.md) を参照してください。
 
 ### Verify before updating

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -151,7 +151,7 @@ MySQL を primary write にしている場合:
 GitHub Release まで載せる場合:
 
 ```bash
-./scripts/publish_sqlite_release.sh postgres v0.1.1
+./scripts/publish_sqlite_release.sh postgres v0.1.4
 ```
 
 生成される bundle の中身と検証方法は [`docs/ARTIFACTS.md`](./ARTIFACTS.md) を参照してください。

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,13 +14,13 @@ GitHub Release asset まで載せるための導線です。
 PostgreSQL を primary write にしている場合は次です。
 
 ```bash
-./scripts/publish_sqlite_release.sh postgres v0.1.1
+./scripts/publish_sqlite_release.sh postgres v0.1.4
 ```
 
 MySQL を primary write にしている場合は次です。
 
 ```bash
-./scripts/publish_sqlite_release.sh mysql v0.1.1
+./scripts/publish_sqlite_release.sh mysql v0.1.4
 ```
 
 この script は次をまとめて行います。
@@ -37,6 +37,9 @@ MySQL を primary write にしている場合は次です。
 - `gh auth login` 済みであること
 - 指定する tag が **現在の HEAD と同じ commit** を向いていること
 - tag が remote に push 済みであること
+- 公開済み tag を載せ替えず、新しい patch tag を使うこと
+
+上の例は、最新 tag が `v0.1.3` の状態から `v0.1.4` を切る想定です。
 
 ## Local-only bundle
 
@@ -57,6 +60,9 @@ MySQL の場合:
 publish script は、指定 tag が現在の `HEAD` を向いていない場合に失敗します。
 公開済み tag が古い commit を向いている状態で release 内容を増やしたいときは、
 公開 tag を載せ替えるよりも次の patch tag を切る方が事故が少なくなります。
+
+`v0.1.0` は初回公開 tag としてそのまま残します。
+release trust hardening を入れた成果物は、`v0.1.x` の新しい patch tag で公開してください。
 
 ## Outputs
 
@@ -85,6 +91,40 @@ manifest には少なくとも次を入れます。
 - `tool_version`
 
 詳しい bundle 中身は [`docs/ARTIFACTS.md`](./ARTIFACTS.md) を参照してください。
+
+## Consumer verification
+
+GitHub Release から asset を取得して検証する最短経路です。
+
+```bash
+REPO=mt4110/station_converter_ja
+TAG=v0.1.4
+mkdir -p "tmp/release-${TAG}"
+gh release download "$TAG" -R "$REPO" -D "tmp/release-${TAG}" --clobber \
+  -p stations.sqlite3 \
+  -p manifest.json \
+  -p SOURCE_METADATA.json \
+  -p checksums.txt \
+  -p CHANGELOG.md \
+  -p RELEASE_NOTES.md \
+  -p README_SQLITE.md \
+  -p SBOM.spdx.json
+cd "tmp/release-${TAG}"
+shasum -a 256 -c checksums.txt
+gh attestation verify stations.sqlite3 -R "$REPO"
+gh attestation verify stations.sqlite3 -R "$REPO" \
+  --predicate-type https://spdx.dev/Document/v2.3
+```
+
+Linux で `sha256sum` がある環境なら、checksum は次でも同じです。
+
+```bash
+sha256sum -c checksums.txt
+```
+
+`manifest.json` と `SOURCE_METADATA.json` で source snapshot、row counts、git commit を確認できます。
+この artifact が主張する freshness は latest available MLIT N02 snapshot であり、
+real-time railway data ではありません。
 
 ## GitHub Release workflow
 

--- a/scripts/build_release_bundle.py
+++ b/scripts/build_release_bundle.py
@@ -379,11 +379,12 @@ def render_release_notes(
 ) -> str:
     row_counts = manifest["row_counts"]
     snapshot_counts = manifest["snapshot_counts"]
-    verify_hint = (
-        f"gh attestation verify stations.sqlite3 -R {git_repo_slug}"
-        if git_repo_slug
-        else "gh attestation verify stations.sqlite3 -R <owner/repo>"
+    repo_hint = git_repo_slug or "<owner/repo>"
+    verification_commands = render_consumer_verification_commands(
+        release_version=release_version,
+        repo_hint=repo_hint,
     )
+    verification_block = textwrap.indent(verification_commands, "        ")
 
     return textwrap.dedent(
         f"""
@@ -430,9 +431,11 @@ def render_release_notes(
         ## Verification
 
         ```bash
-        sha256sum -c checksums.txt
-        {verify_hint}
+{verification_block}
         ```
+
+        This artifact represents the latest available MLIT N02 snapshot included
+        in this release. It is not real-time railway data.
         """
     ).strip()
 
@@ -443,12 +446,13 @@ def render_readme_sqlite(
     manifest: Dict[str, Any],
     git_repo_slug: Optional[str],
 ) -> str:
-    verify_hint = (
-        f"gh attestation verify stations.sqlite3 -R {git_repo_slug}"
-        if git_repo_slug
-        else "gh attestation verify stations.sqlite3 -R <owner/repo>"
-    )
+    repo_hint = git_repo_slug or "<owner/repo>"
     source_version = manifest["source_version"] or "unknown"
+    verification_commands = render_consumer_verification_commands(
+        release_version=release_version,
+        repo_hint=repo_hint,
+    )
+    verification_block = textwrap.indent(verification_commands, "        ")
 
     return textwrap.dedent(
         f"""
@@ -461,11 +465,10 @@ def render_readme_sqlite(
         - source_version: `{source_version}`
         - git_commit: `{manifest["git_commit"]}`
 
-        まずは次で検証できます。
+        GitHub Release から取得して検証する場合:
 
         ```bash
-        sha256sum -c checksums.txt
-        {verify_hint}
+{verification_block}
         ```
 
         SQLite を開く例:
@@ -485,6 +488,31 @@ def render_readme_sqlite(
         ```
 
         provenance と source metadata は `manifest.json` と `SOURCE_METADATA.json` を参照してください。
+        この artifact は latest available MLIT N02 snapshot の配布物であり、real-time railway data ではありません。
+        """
+    ).strip()
+
+
+def render_consumer_verification_commands(*, release_version: str, repo_hint: str) -> str:
+    return textwrap.dedent(
+        f"""
+        REPO="{repo_hint}"
+        TAG="{release_version}"
+        mkdir -p "tmp/release-${{TAG}}"
+        gh release download "$TAG" -R "$REPO" -D "tmp/release-${{TAG}}" --clobber \\
+          -p stations.sqlite3 \\
+          -p manifest.json \\
+          -p SOURCE_METADATA.json \\
+          -p checksums.txt \\
+          -p CHANGELOG.md \\
+          -p RELEASE_NOTES.md \\
+          -p README_SQLITE.md \\
+          -p SBOM.spdx.json
+        cd "tmp/release-${{TAG}}"
+        shasum -a 256 -c checksums.txt
+        gh attestation verify stations.sqlite3 -R "$REPO"
+        gh attestation verify stations.sqlite3 -R "$REPO" \\
+          --predicate-type https://spdx.dev/Document/v2.3
         """
     ).strip()
 

--- a/scripts/build_release_bundle.py
+++ b/scripts/build_release_bundle.py
@@ -509,7 +509,14 @@ def render_consumer_verification_commands(*, release_version: str, repo_hint: st
           -p README_SQLITE.md \\
           -p SBOM.spdx.json
         cd "tmp/release-${{TAG}}"
-        shasum -a 256 -c checksums.txt
+        if command -v sha256sum >/dev/null 2>&1; then
+          sha256sum -c checksums.txt
+        elif command -v shasum >/dev/null 2>&1; then
+          shasum -a 256 -c checksums.txt
+        else
+          echo "Neither sha256sum nor shasum is available for checksum verification." >&2
+          exit 1
+        fi
         gh attestation verify stations.sqlite3 -R "$REPO"
         gh attestation verify stations.sqlite3 -R "$REPO" \\
           --predicate-type https://spdx.dev/Document/v2.3

--- a/scripts/publish_sqlite_release.sh
+++ b/scripts/publish_sqlite_release.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   echo "usage: $0 [postgres|mysql] <release-tag>" >&2
-  echo "example: $0 postgres v0.1.1" >&2
+  echo "example: $0 postgres v0.1.4" >&2
 }
 
 DB_TYPE="${1:-}"

--- a/scripts/verify_release_bundle.py
+++ b/scripts/verify_release_bundle.py
@@ -28,6 +28,15 @@ REQUIRED_MANIFEST_KEYS = [
     "row_counts",
 ]
 
+REQUIRED_CONSUMER_VERIFICATION_TEXT = [
+    "gh release download",
+    "shasum -a 256 -c checksums.txt",
+    "gh attestation verify stations.sqlite3",
+    "--predicate-type https://spdx.dev/Document/v2.3",
+    "latest available MLIT N02 snapshot",
+    "real-time railway data",
+]
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Verify a generated SQLite release bundle.")
@@ -66,6 +75,7 @@ def main() -> int:
         raise SystemExit("SBOM.spdx.json must declare SPDX-2.3")
 
     verify_checksums(bundle_dir / "checksums.txt", bundle_dir)
+    verify_consumer_docs(bundle_dir)
 
     summary = {
         "bundle_dir": str(bundle_dir),
@@ -100,6 +110,14 @@ def verify_checksums(checksums_path: Path, bundle_dir: Path) -> None:
             raise SystemExit(
                 f"checksum mismatch for {target.name}: expected {expected_hash}, got {actual_hash}"
             )
+
+
+def verify_consumer_docs(bundle_dir: Path) -> None:
+    for file_name in ["RELEASE_NOTES.md", "README_SQLITE.md"]:
+        text = (bundle_dir / file_name).read_text(encoding="utf-8")
+        for required_text in REQUIRED_CONSUMER_VERIFICATION_TEXT:
+            if required_text not in text:
+                raise SystemExit(f"{file_name} missing consumer verification text: {required_text}")
 
 
 def sha256_file(path: Path) -> str:

--- a/scripts/verify_release_bundle.py
+++ b/scripts/verify_release_bundle.py
@@ -30,6 +30,7 @@ REQUIRED_MANIFEST_KEYS = [
 
 REQUIRED_CONSUMER_VERIFICATION_TEXT = [
     "gh release download",
+    "sha256sum -c checksums.txt",
     "shasum -a 256 -c checksums.txt",
     "gh attestation verify stations.sqlite3",
     "--predicate-type https://spdx.dev/Document/v2.3",


### PR DESCRIPTION
## Summary

- Refresh README / README_EN / release docs around the v0.1.4 patch release path without moving existing tags.
- Add a consumer verification path from GitHub Release download to checksum verification, provenance attestation, and SBOM attestation.
- Align generated RELEASE_NOTES.md and README_SQLITE.md with that verification path, and make bundle verification guard the required guidance.

## Validation

- `./scripts/verify_repo.sh`
- `./scripts/verify_ingest_export.sh postgres`
- `./scripts/verify_ingest_export.sh mysql`
- `python3 scripts/build_release_bundle.py --repo-root . --sqlite-path storage/sqlite/stations.sqlite3 --bundle-dir "$tmp_bundle" --release-version v0.1.4-test --generated-at 2026-04-21T00:00:00Z`
- `python3 scripts/verify_release_bundle.py --bundle-dir "$tmp_bundle"`