### PR TITLE
Bump OpenSSF Scorecard action to v2.4.3

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: scorecard.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- Pin OpenSSF Scorecard action to the latest available v2.4.3 tag
- Restore the scorecard workflow after the unqualified v2 tag failed to resolve

## Verification
- git diff --check