### PR TITLE
Fix OpenSSF Scorecard workflow permissions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,12 +10,14 @@ on:
 
 permissions:
   contents: read
-  id-token: write
-  security-events: write
 
 jobs:
   scorecard:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- Move Scorecard write permissions from workflow scope to the scorecard job
- Keep workflow-level permissions read-only to satisfy Scorecard publishing restrictions

## Verification
- git diff --check